### PR TITLE
Fix syntax and for loop

### DIFF
--- a/slopegraph.html
+++ b/slopegraph.html
@@ -20,7 +20,7 @@
 						context.lineTo(widthOfCanvas, rightValue);
 						context.stroke();
 					};
-					for each (var value in dataset) {
+					for (var value of dataset) {
 						chart(value[0], value[1]);
 					};
 				}


### PR DESCRIPTION
There's no `for each` in JavaScript. For "of" should be used to traverse the values instead of the keys.